### PR TITLE
Updated names of classes and interfaces to correspond more to API documentation

### DIFF
--- a/src/main/java/io/mailtrap/api/BulkEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/BulkEmailsImpl.java
@@ -2,7 +2,7 @@ package io.mailtrap.api;
 
 import io.mailtrap.Constants;
 import io.mailtrap.CustomValidator;
-import io.mailtrap.api.abstractions.EmailSendingApi;
+import io.mailtrap.api.abstractions.BulkEmails;
 import io.mailtrap.api.abstractions.classes.SendApiResource;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.http.RequestData;
@@ -10,13 +10,13 @@ import io.mailtrap.model.request.MailtrapMail;
 import io.mailtrap.model.response.SendResponse;
 
 /**
- * Implementation of the {@link EmailSendingApi} interface for sending emails in the production environment.
+ * Implementation of the {@link BulkEmails} interface for bulk sending emails.
  */
-public class EmailSendingApiImpl extends SendApiResource implements EmailSendingApi {
+public class BulkEmailsImpl extends SendApiResource implements BulkEmails {
 
-    public EmailSendingApiImpl(MailtrapConfig config, CustomValidator customValidator) {
+    public BulkEmailsImpl(MailtrapConfig config, CustomValidator customValidator) {
         super(config, customValidator);
-        this.apiHost = Constants.EMAIL_SENDING_SEND_HOST;
+        this.apiHost = Constants.BULK_SENDING_HOST;
     }
 
     @Override
@@ -28,5 +28,4 @@ public class EmailSendingApiImpl extends SendApiResource implements EmailSending
         }
         return httpClient.post(apiHost + "/api/send", mail, requestData, SendResponse.class);
     }
-
 }

--- a/src/main/java/io/mailtrap/api/SendingEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/SendingEmailsImpl.java
@@ -2,7 +2,7 @@ package io.mailtrap.api;
 
 import io.mailtrap.Constants;
 import io.mailtrap.CustomValidator;
-import io.mailtrap.api.abstractions.BulkSendingApi;
+import io.mailtrap.api.abstractions.SendingEmails;
 import io.mailtrap.api.abstractions.classes.SendApiResource;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.http.RequestData;
@@ -10,13 +10,13 @@ import io.mailtrap.model.request.MailtrapMail;
 import io.mailtrap.model.response.SendResponse;
 
 /**
- * Implementation of the {@link BulkSendingApi} interface for bulk sending emails.
+ * Implementation of the {@link SendingEmails} interface for sending emails in the production environment.
  */
-public class BulkSendingApiImpl extends SendApiResource implements BulkSendingApi {
+public class SendingEmailsImpl extends SendApiResource implements SendingEmails {
 
-    public BulkSendingApiImpl(MailtrapConfig config, CustomValidator customValidator) {
+    public SendingEmailsImpl(MailtrapConfig config, CustomValidator customValidator) {
         super(config, customValidator);
-        this.apiHost = Constants.BULK_SENDING_HOST;
+        this.apiHost = Constants.EMAIL_SENDING_SEND_HOST;
     }
 
     @Override
@@ -28,4 +28,5 @@ public class BulkSendingApiImpl extends SendApiResource implements BulkSendingAp
         }
         return httpClient.post(apiHost + "/api/send", mail, requestData, SendResponse.class);
     }
+
 }

--- a/src/main/java/io/mailtrap/api/TestingEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/TestingEmailsImpl.java
@@ -2,7 +2,7 @@ package io.mailtrap.api;
 
 import io.mailtrap.Constants;
 import io.mailtrap.CustomValidator;
-import io.mailtrap.api.abstractions.EmailTestingApi;
+import io.mailtrap.api.abstractions.TestingEmails;
 import io.mailtrap.api.abstractions.classes.SendApiResource;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.http.RequestData;
@@ -10,11 +10,11 @@ import io.mailtrap.model.request.MailtrapMail;
 import io.mailtrap.model.response.SendResponse;
 
 /**
- * Implementation of the {@link EmailTestingApi} interface for sending emails in the sandbox environment.
+ * Implementation of the {@link TestingEmails} interface for sending emails in the sandbox environment.
  */
-public class EmailTestingApiImpl extends SendApiResource implements EmailTestingApi {
+public class TestingEmailsImpl extends SendApiResource implements TestingEmails {
 
-    public EmailTestingApiImpl(MailtrapConfig config, CustomValidator customValidator) {
+    public TestingEmailsImpl(MailtrapConfig config, CustomValidator customValidator) {
         super(config, customValidator);
         this.apiHost = Constants.EMAIL_TESTING_SEND_HOST;
     }

--- a/src/main/java/io/mailtrap/api/abstractions/BulkEmails.java
+++ b/src/main/java/io/mailtrap/api/abstractions/BulkEmails.java
@@ -8,7 +8,7 @@ import io.mailtrap.model.response.SendResponse;
 /**
  * Interface representing the Mailtrap Bulk Sending API for sending emails.
  */
-public interface BulkSendingApi {
+public interface BulkEmails {
 
     /**
      * Sends an email

--- a/src/main/java/io/mailtrap/api/abstractions/SendingEmails.java
+++ b/src/main/java/io/mailtrap/api/abstractions/SendingEmails.java
@@ -8,7 +8,7 @@ import io.mailtrap.model.response.SendResponse;
 /**
  * Interface representing the Mailtrap Sending API for sending emails.
  */
-public interface EmailSendingApi {
+public interface SendingEmails {
 
     /**
      * Sends an email

--- a/src/main/java/io/mailtrap/api/abstractions/TestingEmails.java
+++ b/src/main/java/io/mailtrap/api/abstractions/TestingEmails.java
@@ -8,7 +8,7 @@ import io.mailtrap.model.response.SendResponse;
 /**
  * Interface representing the Mailtrap Testing API for sending emails.
  */
-public interface EmailTestingApi {
+public interface TestingEmails {
 
     /**
      * Sends an email

--- a/src/main/java/io/mailtrap/client/MailtrapClient.java
+++ b/src/main/java/io/mailtrap/client/MailtrapClient.java
@@ -1,8 +1,8 @@
 package io.mailtrap.client;
 
-import io.mailtrap.client.layers.MailtrapBulkEmailSendingApiLayer;
-import io.mailtrap.client.layers.MailtrapEmailSendingApiLayer;
-import io.mailtrap.client.layers.MailtrapEmailTestingApiLayer;
+import io.mailtrap.client.layers.MailtrapBulkSendingApi;
+import io.mailtrap.client.layers.MailtrapEmailSendingApi;
+import io.mailtrap.client.layers.MailtrapEmailTestingApi;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.model.request.MailtrapMail;
 import io.mailtrap.model.response.SendResponse;
@@ -24,19 +24,19 @@ public class MailtrapClient {
      * API for Mailtrap.io Sending functionality
      */
     @Getter
-    private final MailtrapEmailSendingApiLayer sendingApi;
+    private final MailtrapEmailSendingApi sendingApi;
 
     /**
      * API for Mailtrap.io Testing functionality
      */
     @Getter
-    private final MailtrapEmailTestingApiLayer testingApi;
+    private final MailtrapEmailTestingApi testingApi;
 
     /**
      * API for Mailtrap.io Bulk Sending functionality
      */
     @Getter
-    private final MailtrapBulkEmailSendingApiLayer bulkSendingApi;
+    private final MailtrapBulkSendingApi bulkSendingApi;
 
     /**
      * Utility class which holds sending context (which API to use: Email Sending API, Bulk Sending API or

--- a/src/main/java/io/mailtrap/client/layers/MailtrapBulkSendingApi.java
+++ b/src/main/java/io/mailtrap/client/layers/MailtrapBulkSendingApi.java
@@ -1,16 +1,16 @@
 package io.mailtrap.client.layers;
 
-import io.mailtrap.api.abstractions.EmailTestingApi;
+import io.mailtrap.api.abstractions.BulkEmails;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 
 /**
- * Represents an API for Mailtrap Testing functionality
+ * Represents an API for Mailtrap Bulk Sending functionality
  */
 @Getter
 @Accessors(fluent = true)
 @RequiredArgsConstructor
-public class MailtrapEmailTestingApiLayer {
-    private final EmailTestingApi emails;
+public class MailtrapBulkSendingApi {
+    private final BulkEmails emails;
 }

--- a/src/main/java/io/mailtrap/client/layers/MailtrapEmailSendingApi.java
+++ b/src/main/java/io/mailtrap/client/layers/MailtrapEmailSendingApi.java
@@ -1,6 +1,6 @@
 package io.mailtrap.client.layers;
 
-import io.mailtrap.api.abstractions.EmailSendingApi;
+import io.mailtrap.api.abstractions.SendingEmails;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
@@ -11,6 +11,6 @@ import lombok.experimental.Accessors;
 @Getter
 @Accessors(fluent = true)
 @RequiredArgsConstructor
-public class MailtrapEmailSendingApiLayer {
-    private final EmailSendingApi emails;
+public class MailtrapEmailSendingApi {
+    private final SendingEmails emails;
 }

--- a/src/main/java/io/mailtrap/client/layers/MailtrapEmailTestingApi.java
+++ b/src/main/java/io/mailtrap/client/layers/MailtrapEmailTestingApi.java
@@ -1,16 +1,16 @@
 package io.mailtrap.client.layers;
 
-import io.mailtrap.api.abstractions.BulkSendingApi;
+import io.mailtrap.api.abstractions.TestingEmails;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 
 /**
- * Represents an API for Mailtrap Bulk Sending functionality
+ * Represents an API for Mailtrap Testing functionality
  */
 @Getter
 @Accessors(fluent = true)
 @RequiredArgsConstructor
-public class MailtrapBulkEmailSendingApiLayer {
-    private final BulkSendingApi emails;
+public class MailtrapEmailTestingApi {
+    private final TestingEmails emails;
 }

--- a/src/main/java/io/mailtrap/factory/MailtrapClientFactory.java
+++ b/src/main/java/io/mailtrap/factory/MailtrapClientFactory.java
@@ -1,13 +1,13 @@
 package io.mailtrap.factory;
 
 import io.mailtrap.CustomValidator;
-import io.mailtrap.api.BulkSendingApiImpl;
-import io.mailtrap.api.EmailSendingApiImpl;
-import io.mailtrap.api.EmailTestingApiImpl;
+import io.mailtrap.api.BulkEmailsImpl;
+import io.mailtrap.api.SendingEmailsImpl;
+import io.mailtrap.api.TestingEmailsImpl;
 import io.mailtrap.client.MailtrapClient;
-import io.mailtrap.client.layers.MailtrapBulkEmailSendingApiLayer;
-import io.mailtrap.client.layers.MailtrapEmailSendingApiLayer;
-import io.mailtrap.client.layers.MailtrapEmailTestingApiLayer;
+import io.mailtrap.client.layers.MailtrapBulkSendingApi;
+import io.mailtrap.client.layers.MailtrapEmailSendingApi;
+import io.mailtrap.client.layers.MailtrapEmailTestingApi;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.util.SendingContextHolder;
 import jakarta.validation.Validation;
@@ -48,22 +48,22 @@ public final class MailtrapClientFactory {
                 .build();
     }
 
-    private static MailtrapEmailSendingApiLayer createSendingApi(MailtrapConfig config, CustomValidator customValidator) {
-        var emails = new EmailSendingApiImpl(config, customValidator);
+    private static MailtrapEmailSendingApi createSendingApi(MailtrapConfig config, CustomValidator customValidator) {
+        var emails = new SendingEmailsImpl(config, customValidator);
 
-        return new MailtrapEmailSendingApiLayer(emails);
+        return new MailtrapEmailSendingApi(emails);
     }
 
-    private static MailtrapEmailTestingApiLayer createTestingApi(MailtrapConfig config, CustomValidator customValidator) {
-        var emails = new EmailTestingApiImpl(config, customValidator);
+    private static MailtrapEmailTestingApi createTestingApi(MailtrapConfig config, CustomValidator customValidator) {
+        var emails = new TestingEmailsImpl(config, customValidator);
 
-        return new MailtrapEmailTestingApiLayer(emails);
+        return new MailtrapEmailTestingApi(emails);
     }
 
-    private static MailtrapBulkEmailSendingApiLayer createBulkSendingApi(MailtrapConfig config, CustomValidator customValidator) {
-        var emails = new BulkSendingApiImpl(config, customValidator);
+    private static MailtrapBulkSendingApi createBulkSendingApi(MailtrapConfig config, CustomValidator customValidator) {
+        var emails = new BulkEmailsImpl(config, customValidator);
 
-        return new MailtrapBulkEmailSendingApiLayer(emails);
+        return new MailtrapBulkSendingApi(emails);
     }
 
     /**

--- a/src/test/java/io/mailtrap/api/BulkEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/BulkEmailsImplTest.java
@@ -1,7 +1,7 @@
 package io.mailtrap.api;
 
 import io.mailtrap.Constants;
-import io.mailtrap.api.abstractions.EmailTestingApi;
+import io.mailtrap.api.abstractions.BulkEmails;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.factory.MailtrapClientFactory;
@@ -17,15 +17,14 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class EmailTestingApiImplTest extends BaseSendTest {
-
-    private EmailTestingApi testingApi;
+class BulkEmailsImplTest extends BaseSendTest {
+    private BulkEmails bulkEmails;
 
     @BeforeEach
     public void init() {
         TestHttpClient httpClient = new TestHttpClient(List.of(
                 DataMock.build(
-                        Constants.EMAIL_TESTING_SEND_HOST + "/api/send/" + INBOX_ID,
+                        Constants.BULK_SENDING_HOST + "/api/send",
                         "POST",
                         createValidTestMail().toJson(),
                         """
@@ -39,11 +38,10 @@ class EmailTestingApiImplTest extends BaseSendTest {
         MailtrapConfig testConfig = new MailtrapConfig.Builder()
                 .httpClient(httpClient)
                 .token("dummy_token")
-                .sandbox(true)
-                .inboxId(INBOX_ID)
+                .bulk(true)
                 .build();
 
-        testingApi = MailtrapClientFactory.createMailtrapClient(testConfig).testingApi().emails();
+        bulkEmails = MailtrapClientFactory.createMailtrapClient(testConfig).bulkSendingApi().emails();
     }
 
     @Test
@@ -52,7 +50,7 @@ class EmailTestingApiImplTest extends BaseSendTest {
         MailtrapMail mail = createInvalidTestMail();
 
         // Assert
-        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
         assertEquals(INVALID_REQUEST_EMPTY_BODY_FROM_EMAIL, exception.getMessage());
     }
 
@@ -62,7 +60,7 @@ class EmailTestingApiImplTest extends BaseSendTest {
         MailtrapMail mail = createTestMailWithoutTemplateUuidAndTextAndHtml();
 
         // Assert
-        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
         assertEquals(TEMPLATE_UUID_OR_TEXT_OR_HTML_MUST_NOT_BE_EMPTY, exception.getMessage());
     }
 
@@ -72,7 +70,7 @@ class EmailTestingApiImplTest extends BaseSendTest {
         MailtrapMail mail = createTestMailWithTemplateUuidAndText();
 
         // Assert
-        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
         assertEquals(TEMPLATE_UUID_IS_USED_TEXT_AND_HTML_SHOULD_BE_EMPTY, exception.getMessage());
     }
 
@@ -82,7 +80,7 @@ class EmailTestingApiImplTest extends BaseSendTest {
         MailtrapMail mail = createTestMailWithTemplateUuidAndHtml();
 
         // Assert
-        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
         assertEquals(TEMPLATE_UUID_IS_USED_TEXT_AND_HTML_SHOULD_BE_EMPTY, exception.getMessage());
     }
 
@@ -92,14 +90,14 @@ class EmailTestingApiImplTest extends BaseSendTest {
         MailtrapMail mail = createTestMailWithTemplateVariablesAndHtml();
 
         // Assert
-        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
         assertEquals(TEMPLATE_VARIABLES_SHOULD_BE_USED_WITH_TEMPLATE_UUID, exception.getMessage());
     }
 
     @Test
     void send_NullableMail_ThrowsInvalidRequestBodyException() {
         // Assert
-        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(null, INBOX_ID));
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(null));
         assertEquals(MAIL_MUST_NOT_BE_NULL, exception.getMessage());
     }
 
@@ -109,11 +107,10 @@ class EmailTestingApiImplTest extends BaseSendTest {
         var mail = createValidTestMail();
 
         // Perform call
-        SendResponse response = testingApi.send(mail, INBOX_ID);
+        SendResponse response = bulkEmails.send(mail);
 
         // Assert
         assertTrue(response.isSuccess());
         assertEquals("11111", response.getMessageIds().get(0));
     }
-
 }

--- a/src/test/java/io/mailtrap/api/SendingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/SendingEmailsImplTest.java
@@ -1,7 +1,7 @@
 package io.mailtrap.api;
 
 import io.mailtrap.Constants;
-import io.mailtrap.api.abstractions.EmailSendingApi;
+import io.mailtrap.api.abstractions.SendingEmails;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.factory.MailtrapClientFactory;
@@ -17,9 +17,9 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class EmailSendingApiImplTest extends BaseSendTest {
+class SendingEmailsImplTest extends BaseSendTest {
 
-    private EmailSendingApi sendApi;
+    private SendingEmails sendApi;
 
     @BeforeEach
     public void init() {


### PR DESCRIPTION
## Motivation
This way classes and interfaces structure is more lookalike to API documentation

## Changes

- Renamed existing Bulk, Sending and Testing classes and interfaces
