### PR TITLE
Replace ralsware github org with mailtrap org

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Refer to the [`examples`](examples) folder for the source code of this and other
 
 ### API Reference
 
-You can find the API reference [here](https://railsware.github.io/mailtrap-java/index.html).
+You can find the API reference [here](https://mailtrap.github.io/mailtrap-java/index.html).
 
 ### General API
 
@@ -144,7 +144,7 @@ You can find the API reference [here](https://railsware.github.io/mailtrap-java/
 
 ## Contributing
 
-Bug reports and pull requests are welcome on [GitHub](https://github.com/railsware/mailtrap-java). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on [GitHub](https://github.com/mailtrap/mailtrap-java). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,4 @@ This client allows you to quickly and easily integrate your Java application wit
 
 ## License
 
-Licensed under the <a href="https://github.com/railsware/mailtrap-java/blob/main/LICENSE.txt" target="_blank">MIT License</a>.
+Licensed under the <a href="https://github.com/mailtrap/mailtrap-java/blob/main/LICENSE.txt" target="_blank">MIT License</a>.

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,3 +1,3 @@
 # Detailed Usage Examples
 
-Code examples covering all APIs can be found <a href="https://github.com/railsware/mailtrap-java/tree/main/examples/java/io/mailtrap/examples" target="_blank">here</a>.
+Code examples covering all APIs can be found <a href="https://github.com/mailtrap/mailtrap-java/tree/main/examples/java/io/mailtrap/examples" target="_blank">here</a>.

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </developers>
 
     <scm>
-        <url>https://github.com/railsware/mailtrap-java</url>
-        <connection>scm:git:git://github.com/railsware/mailtrap-java.git</connection>
+        <url>https://github.com/mailtrap/mailtrap-java</url>
+        <connection>scm:git:git://github.com/mailtrap/mailtrap-java.git</connection>
     </scm>
 
     <properties>

--- a/src/main/java/io/mailtrap/http/impl/DefaultMailtrapHttpClient.java
+++ b/src/main/java/io/mailtrap/http/impl/DefaultMailtrapHttpClient.java
@@ -169,7 +169,7 @@ public class DefaultMailtrapHttpClient implements CustomHttpClient {
                 .header("Accept", "application/json")
                 .header("Content-Type", "application/json; charset=UTF-8")
                 .header("Authorization", "Bearer " + token)
-                .header("User-Agent", "mailtrap-java (https://github.com/railsware/mailtrap-java)");
+                .header("User-Agent", "mailtrap-java (https://github.com/mailtrap/mailtrap-java)");
 
         final Map<String, Object> headers = new HashMap<>(requestData.getHeaders());
         for (Map.Entry<String, ?> entry : headers.entrySet()) {


### PR DESCRIPTION
## Motivation
Transfer the ownership from `railsware` org to `mailtrap` Github org.

## Changes

- Minor changes in readme and docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference URLs and contributing section links across README and documentation to reflect current project location
  * Updated license link to point to current repository

* **Chores**
  * Updated build configuration and project metadata with current repository reference
  * Updated User-Agent header to reflect current repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->