### PR TITLE
Bump central publishing maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.5.0</version>
+k                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,12 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-k                <version>0.11.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## Motivation


## Changes

- Bump central-publishing-maven-plugin version
- Update deploy config not to wait until new SDK version is fully published

## How to test

- [ ] Merge this PR
- [ ] Draft, review, approve, merge release PR
- [ ] Trigger workflow to deliver new SDK version
- [ ] Assert version is released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Maven publishing workflow to use the latest publishing plugin version.
  * Builds now proceed after Central validation rather than waiting for publication completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->