### PR TITLE
Add sending domain update and company info endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ You can find the [Mailtrap Java API reference](https://mailtrap.github.io/mailtr
 - [Send using template](examples/java/io/mailtrap/examples/sending/TemplateExample.java)
 - [Batch](examples/java/io/mailtrap/examples/sending/BatchExample.java)
 - [Sending Domains](examples/java/io/mailtrap/examples/sendingdomains/SendingDomainsExample.java)
+- [Company Info](examples/java/io/mailtrap/examples/companyinfo/CompanyInfoExample.java)
 - [Suppressions](examples/java/io/mailtrap/examples/suppressions/SuppressionsExample.java)
 - [Stats](examples/java/io/mailtrap/examples/sending/StatsExample.java)
 - [Email Logs](examples/java/io/mailtrap/examples/emaillogs/EmailLogsExample.java)

--- a/examples/java/io/mailtrap/examples/companyinfo/CompanyInfoExample.java
+++ b/examples/java/io/mailtrap/examples/companyinfo/CompanyInfoExample.java
@@ -1,0 +1,51 @@
+package io.mailtrap.examples.companyinfo;
+
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.companyinfo.CreateCompanyInfoRequest;
+import io.mailtrap.model.request.companyinfo.UpdateCompanyInfoRequest;
+
+public class CompanyInfoExample {
+
+    private static final String TOKEN = System.getenv("MAILTRAP_API_KEY");
+    private static final long DOMAIN_ID = Long.parseLong(System.getenv("MAILTRAP_DOMAIN_ID"));
+
+    public static void main(String[] args) {
+        final var config = new MailtrapConfig.Builder()
+            .token(TOKEN)
+            .build();
+
+        final var client = MailtrapClientFactory.createMailtrapClient(config);
+
+        final var createRequest = new CreateCompanyInfoRequest(
+            CreateCompanyInfoRequest.CompanyInfoData.builder()
+                .name("Mailtrap")
+                .address("123 Main St")
+                .city("San Francisco")
+                .country("US")
+                .zipCode("94105")
+                .websiteUrl("https://mailtrap.io")
+                .phone("+1-555-0100")
+                .privacyPolicyUrl("https://mailtrap.io/privacy")
+                .termsOfServiceUrl("https://mailtrap.io/terms")
+                .infoLevel("business")
+                .build()
+        );
+
+        final var created = client.sendingApi().companyInfo().createCompanyInfo(DOMAIN_ID, createRequest);
+        System.out.println(created.getData());
+
+        final var companyInfo = client.sendingApi().companyInfo().getCompanyInfo(DOMAIN_ID);
+        System.out.println(companyInfo.getData());
+
+        final var updateRequest = new UpdateCompanyInfoRequest(
+            UpdateCompanyInfoRequest.CompanyInfoData.builder()
+                .city("New York")
+                .zipCode("10001")
+                .build()
+        );
+
+        final var updated = client.sendingApi().companyInfo().updateCompanyInfo(DOMAIN_ID, updateRequest);
+        System.out.println(updated.getData());
+    }
+}

--- a/examples/java/io/mailtrap/examples/sendingdomains/SendingDomainsExample.java
+++ b/examples/java/io/mailtrap/examples/sendingdomains/SendingDomainsExample.java
@@ -4,6 +4,7 @@ import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.factory.MailtrapClientFactory;
 import io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest;
 import io.mailtrap.model.request.sendingdomains.SendingDomainsSetupInstructionsRequest;
+import io.mailtrap.model.request.sendingdomains.UpdateSendingDomainRequest;
 
 import static io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest.SendingDomainData;
 
@@ -31,6 +32,18 @@ public class SendingDomainsExample {
 
         final var allDomains = client.sendingApi().domains().getSendingDomains(ACCOUNT_ID);
         System.out.println(allDomains);
+
+        final var updateRequest = new UpdateSendingDomainRequest(
+            UpdateSendingDomainRequest.SendingDomainData.builder()
+                .openTrackingEnabled(true)
+                .clickTrackingEnabled(true)
+                .trackingOptOutEnabled(true)
+                .autoUnsubscribeLinkEnabled(false)
+                .build()
+        );
+
+        final var updatedDomain = client.sendingApi().domains().update(ACCOUNT_ID, createdDomain.getId(), updateRequest);
+        System.out.println(updatedDomain);
 
         final var sendInstructionsRequest = new SendingDomainsSetupInstructionsRequest(DEVOPS_EMAIL);
         client.sendingApi().domains().sendSendingDomainsSetupInstructions(ACCOUNT_ID, createdDomain.getId(), sendInstructionsRequest);

--- a/src/main/java/io/mailtrap/api/companyinfo/CompanyInfo.java
+++ b/src/main/java/io/mailtrap/api/companyinfo/CompanyInfo.java
@@ -1,0 +1,35 @@
+package io.mailtrap.api.companyinfo;
+
+import io.mailtrap.model.request.companyinfo.CreateCompanyInfoRequest;
+import io.mailtrap.model.request.companyinfo.UpdateCompanyInfoRequest;
+import io.mailtrap.model.response.companyinfo.CompanyInfoResponse;
+
+public interface CompanyInfo {
+
+    /**
+     * Get the company info associated with a sending domain
+     *
+     * @param sendingDomainId unique domain ID
+     * @return company info of the sending domain
+     */
+    CompanyInfoResponse getCompanyInfo(long sendingDomainId);
+
+    /**
+     * Create the company info for a sending domain. Company info is required for
+     * domain compliance verification.
+     *
+     * @param sendingDomainId unique domain ID
+     * @param request         request data
+     * @return created company info
+     */
+    CompanyInfoResponse createCompanyInfo(long sendingDomainId, CreateCompanyInfoRequest request);
+
+    /**
+     * Update the company info for a sending domain
+     *
+     * @param sendingDomainId unique domain ID
+     * @param request         request data, only the fields set are sent
+     * @return updated company info
+     */
+    CompanyInfoResponse updateCompanyInfo(long sendingDomainId, UpdateCompanyInfoRequest request);
+}

--- a/src/main/java/io/mailtrap/api/companyinfo/CompanyInfoImpl.java
+++ b/src/main/java/io/mailtrap/api/companyinfo/CompanyInfoImpl.java
@@ -1,0 +1,50 @@
+package io.mailtrap.api.companyinfo;
+
+import io.mailtrap.Constants;
+import io.mailtrap.api.apiresource.ApiResource;
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.http.RequestData;
+import io.mailtrap.model.request.companyinfo.CreateCompanyInfoRequest;
+import io.mailtrap.model.request.companyinfo.UpdateCompanyInfoRequest;
+import io.mailtrap.model.response.companyinfo.CompanyInfoResponse;
+
+public class CompanyInfoImpl extends ApiResource implements CompanyInfo {
+
+    public CompanyInfoImpl(final MailtrapConfig config) {
+        super(config);
+        this.apiHost = Constants.GENERAL_HOST;
+    }
+
+    @Override
+    public CompanyInfoResponse getCompanyInfo(final long sendingDomainId) {
+        return httpClient.get(
+            companyInfoPath(sendingDomainId),
+            new RequestData(),
+            CompanyInfoResponse.class
+        );
+    }
+
+    @Override
+    public CompanyInfoResponse createCompanyInfo(final long sendingDomainId, final CreateCompanyInfoRequest request) {
+        return httpClient.post(
+            companyInfoPath(sendingDomainId),
+            request,
+            new RequestData(),
+            CompanyInfoResponse.class
+        );
+    }
+
+    @Override
+    public CompanyInfoResponse updateCompanyInfo(final long sendingDomainId, final UpdateCompanyInfoRequest request) {
+        return httpClient.patch(
+            companyInfoPath(sendingDomainId),
+            request,
+            new RequestData(),
+            CompanyInfoResponse.class
+        );
+    }
+
+    private String companyInfoPath(final long sendingDomainId) {
+        return String.format(apiHost + "/api/domains/%d/company_info", sendingDomainId);
+    }
+}

--- a/src/main/java/io/mailtrap/api/sendingdomains/SendingDomains.java
+++ b/src/main/java/io/mailtrap/api/sendingdomains/SendingDomains.java
@@ -2,6 +2,7 @@ package io.mailtrap.api.sendingdomains;
 
 import io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest;
 import io.mailtrap.model.request.sendingdomains.SendingDomainsSetupInstructionsRequest;
+import io.mailtrap.model.request.sendingdomains.UpdateSendingDomainRequest;
 import io.mailtrap.model.response.sendingdomains.SendingDomainsResponse;
 
 import java.util.List;
@@ -33,6 +34,16 @@ public interface SendingDomains {
      * @return domain attributes, DNS records, status
      */
     SendingDomainsResponse getSendingDomain(long accountId, long sendingDomainId);
+
+    /**
+     * Update configuration settings for a sending domain
+     *
+     * @param accountId       unique account ID
+     * @param sendingDomainId unique domain ID
+     * @param request         request data, only the fields set are sent
+     * @return updated domain attributes, DNS records, status
+     */
+    SendingDomainsResponse update(long accountId, long sendingDomainId, UpdateSendingDomainRequest request);
 
     /**
      * Send sending domain setup instructions

--- a/src/main/java/io/mailtrap/api/sendingdomains/SendingDomainsImpl.java
+++ b/src/main/java/io/mailtrap/api/sendingdomains/SendingDomainsImpl.java
@@ -6,6 +6,7 @@ import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.http.RequestData;
 import io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest;
 import io.mailtrap.model.request.sendingdomains.SendingDomainsSetupInstructionsRequest;
+import io.mailtrap.model.request.sendingdomains.UpdateSendingDomainRequest;
 import io.mailtrap.model.response.sendingdomains.SendingDomainsResponse;
 
 import java.util.List;
@@ -40,6 +41,16 @@ public class SendingDomainsImpl extends ApiResource implements SendingDomains {
     public SendingDomainsResponse getSendingDomain(final long accountId, final long sendingDomainId) {
         return httpClient.get(
             String.format(apiHost + "/api/accounts/%d/sending_domains/%d", accountId, sendingDomainId),
+            new RequestData(),
+            SendingDomainsResponse.class
+        );
+    }
+
+    @Override
+    public SendingDomainsResponse update(final long accountId, final long sendingDomainId, final UpdateSendingDomainRequest request) {
+        return httpClient.patch(
+            String.format(apiHost + "/api/accounts/%d/sending_domains/%d", accountId, sendingDomainId),
+            request,
             new RequestData(),
             SendingDomainsResponse.class
         );

--- a/src/main/java/io/mailtrap/client/api/MailtrapEmailSendingApi.java
+++ b/src/main/java/io/mailtrap/client/api/MailtrapEmailSendingApi.java
@@ -1,5 +1,6 @@
 package io.mailtrap.client.api;
 
+import io.mailtrap.api.companyinfo.CompanyInfo;
 import io.mailtrap.api.emaillogs.EmailLogs;
 import io.mailtrap.api.sendingdomains.SendingDomains;
 import io.mailtrap.api.sendingemails.SendingEmails;
@@ -18,6 +19,7 @@ import lombok.experimental.Accessors;
 public class MailtrapEmailSendingApi {
     private final SendingEmails emails;
     private final SendingDomains domains;
+    private final CompanyInfo companyInfo;
     private final Suppressions suppressions;
     private final Stats stats;
     private final EmailLogs emailLogs;

--- a/src/main/java/io/mailtrap/factory/MailtrapClientFactory.java
+++ b/src/main/java/io/mailtrap/factory/MailtrapClientFactory.java
@@ -24,6 +24,7 @@ import io.mailtrap.api.messages.MessagesImpl;
 import io.mailtrap.api.permissions.PermissionsImpl;
 import io.mailtrap.api.projects.ProjectsImpl;
 import io.mailtrap.api.emaillogs.EmailLogsImpl;
+import io.mailtrap.api.companyinfo.CompanyInfoImpl;
 import io.mailtrap.api.sendingdomains.SendingDomainsImpl;
 import io.mailtrap.api.sendingemails.SendingEmailsImpl;
 import io.mailtrap.api.stats.StatsImpl;
@@ -134,11 +135,12 @@ public final class MailtrapClientFactory {
     private static MailtrapEmailSendingApi createSendingApi(final MailtrapConfig config) {
         final var emails = new SendingEmailsImpl(config, VALIDATOR);
         final var domains = new SendingDomainsImpl(config);
+        final var companyInfo = new CompanyInfoImpl(config);
         final var suppressions = new SuppressionsImpl(config);
         final var stats = new StatsImpl(config);
         final var emailLogs = new EmailLogsImpl(config);
 
-        return new MailtrapEmailSendingApi(emails, domains, suppressions, stats, emailLogs);
+        return new MailtrapEmailSendingApi(emails, domains, companyInfo, suppressions, stats, emailLogs);
     }
 
     private static MailtrapEmailTestingApi createTestingApi(final MailtrapConfig config) {

--- a/src/main/java/io/mailtrap/model/request/companyinfo/CreateCompanyInfoRequest.java
+++ b/src/main/java/io/mailtrap/model/request/companyinfo/CreateCompanyInfoRequest.java
@@ -1,0 +1,50 @@
+package io.mailtrap.model.request.companyinfo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.mailtrap.model.AbstractModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateCompanyInfoRequest extends AbstractModel {
+
+    @JsonProperty("company_info")
+    private CompanyInfoData companyInfo;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CompanyInfoData {
+
+        private String name;
+
+        private String address;
+
+        private String city;
+
+        private String country;
+
+        @JsonProperty("zip_code")
+        private String zipCode;
+
+        @JsonProperty("website_url")
+        private String websiteUrl;
+
+        private String phone;
+
+        @JsonProperty("privacy_policy_url")
+        private String privacyPolicyUrl;
+
+        @JsonProperty("terms_of_service_url")
+        private String termsOfServiceUrl;
+
+        @JsonProperty("info_level")
+        private String infoLevel;
+
+    }
+
+}

--- a/src/main/java/io/mailtrap/model/request/companyinfo/UpdateCompanyInfoRequest.java
+++ b/src/main/java/io/mailtrap/model/request/companyinfo/UpdateCompanyInfoRequest.java
@@ -1,0 +1,50 @@
+package io.mailtrap.model.request.companyinfo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.mailtrap.model.AbstractModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateCompanyInfoRequest extends AbstractModel {
+
+    @JsonProperty("company_info")
+    private CompanyInfoData companyInfo;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CompanyInfoData {
+
+        private String name;
+
+        private String address;
+
+        private String city;
+
+        private String country;
+
+        private String phone;
+
+        @JsonProperty("zip_code")
+        private String zipCode;
+
+        @JsonProperty("privacy_policy_url")
+        private String privacyPolicyUrl;
+
+        @JsonProperty("terms_of_service_url")
+        private String termsOfServiceUrl;
+
+        @JsonProperty("website_url")
+        private String websiteUrl;
+
+        @JsonProperty("info_level")
+        private String infoLevel;
+
+    }
+
+}

--- a/src/main/java/io/mailtrap/model/request/sendingdomains/UpdateSendingDomainRequest.java
+++ b/src/main/java/io/mailtrap/model/request/sendingdomains/UpdateSendingDomainRequest.java
@@ -1,0 +1,40 @@
+package io.mailtrap.model.request.sendingdomains;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.mailtrap.model.AbstractModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateSendingDomainRequest extends AbstractModel {
+
+    @JsonProperty("sending_domain")
+    private SendingDomainData sendingDomain;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class SendingDomainData {
+
+        @JsonProperty("open_tracking_enabled")
+        private Boolean openTrackingEnabled;
+
+        @JsonProperty("click_tracking_enabled")
+        private Boolean clickTrackingEnabled;
+
+        @JsonProperty("tracking_opt_out_enabled")
+        private Boolean trackingOptOutEnabled;
+
+        @JsonProperty("auto_unsubscribe_link_enabled")
+        private Boolean autoUnsubscribeLinkEnabled;
+
+        @JsonProperty("inbound_enabled")
+        private Boolean inboundEnabled;
+
+    }
+
+}

--- a/src/main/java/io/mailtrap/model/response/companyinfo/CompanyInfo.java
+++ b/src/main/java/io/mailtrap/model/response/companyinfo/CompanyInfo.java
@@ -1,0 +1,34 @@
+package io.mailtrap.model.response.companyinfo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class CompanyInfo {
+
+    private String name;
+
+    private String address;
+
+    private String city;
+
+    private String country;
+
+    private String phone;
+
+    @JsonProperty("zip_code")
+    private String zipCode;
+
+    @JsonProperty("privacy_policy_url")
+    private String privacyPolicyUrl;
+
+    @JsonProperty("terms_of_service_url")
+    private String termsOfServiceUrl;
+
+    @JsonProperty("website_url")
+    private String websiteUrl;
+
+    @JsonProperty("info_level")
+    private String infoLevel;
+
+}

--- a/src/main/java/io/mailtrap/model/response/companyinfo/CompanyInfoResponse.java
+++ b/src/main/java/io/mailtrap/model/response/companyinfo/CompanyInfoResponse.java
@@ -1,0 +1,10 @@
+package io.mailtrap.model.response.companyinfo;
+
+import lombok.Data;
+
+@Data
+public class CompanyInfoResponse {
+
+    private CompanyInfo data;
+
+}

--- a/src/main/java/io/mailtrap/model/response/sendingdomains/SendingDomainsResponse.java
+++ b/src/main/java/io/mailtrap/model/response/sendingdomains/SendingDomainsResponse.java
@@ -30,6 +30,9 @@ public class SendingDomainsResponse {
     @JsonProperty("click_tracking_enabled")
     private boolean clickTrackingEnabled;
 
+    @JsonProperty("tracking_opt_out_enabled")
+    private boolean trackingOptOutEnabled;
+
     @JsonProperty("auto_unsubscribe_link_enabled")
     private boolean autoUnsubscribeLinkEnabled;
 

--- a/src/test/java/io/mailtrap/api/companyinfo/CompanyInfoImplTest.java
+++ b/src/test/java/io/mailtrap/api/companyinfo/CompanyInfoImplTest.java
@@ -1,0 +1,101 @@
+package io.mailtrap.api.companyinfo;
+
+import io.mailtrap.Constants;
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.companyinfo.CreateCompanyInfoRequest;
+import io.mailtrap.model.request.companyinfo.UpdateCompanyInfoRequest;
+import io.mailtrap.model.response.companyinfo.CompanyInfoResponse;
+import io.mailtrap.testutils.BaseTest;
+import io.mailtrap.testutils.DataMock;
+import io.mailtrap.testutils.TestHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CompanyInfoImplTest extends BaseTest {
+
+    private final long domainId = 12345L;
+
+    private CompanyInfo companyInfo;
+
+    @BeforeEach
+    public void init() {
+        final String companyInfoUrl = Constants.GENERAL_HOST + "/api/domains/" + domainId + "/company_info";
+
+        final TestHttpClient httpClient = new TestHttpClient(List.of(
+            DataMock.build(
+                companyInfoUrl,
+                "GET", null, "api/company_info/companyInfoResponse.json"
+            ),
+            DataMock.build(
+                companyInfoUrl,
+                "POST", "api/company_info/createCompanyInfoRequest.json", "api/company_info/companyInfoResponse.json"
+            ),
+            DataMock.build(
+                companyInfoUrl,
+                "PATCH", "api/company_info/updateCompanyInfoRequest.json", "api/company_info/companyInfoResponse.json"
+            )
+        ));
+
+        final MailtrapConfig testConfig = new MailtrapConfig.Builder()
+            .httpClient(httpClient)
+            .token("dummy_token")
+            .build();
+
+        companyInfo = MailtrapClientFactory.createMailtrapClient(testConfig).sendingApi().companyInfo();
+    }
+
+    @Test
+    void test_getCompanyInfo() {
+        final CompanyInfoResponse response = companyInfo.getCompanyInfo(domainId);
+
+        assertNotNull(response);
+        assertNotNull(response.getData());
+        assertEquals("Mailtrap", response.getData().getName());
+        assertEquals("San Francisco", response.getData().getCity());
+        assertEquals("94105", response.getData().getZipCode());
+        assertEquals("business", response.getData().getInfoLevel());
+    }
+
+    @Test
+    void test_createCompanyInfo() {
+        final CompanyInfoResponse response = companyInfo.createCompanyInfo(
+            domainId,
+            new CreateCompanyInfoRequest(
+                CreateCompanyInfoRequest.CompanyInfoData.builder()
+                    .name("Mailtrap")
+                    .address("123 Main St")
+                    .city("San Francisco")
+                    .country("US")
+                    .zipCode("94105")
+                    .websiteUrl("https://mailtrap.io")
+                    .infoLevel("business")
+                    .build()
+            )
+        );
+
+        assertNotNull(response);
+        assertEquals("Mailtrap", response.getData().getName());
+    }
+
+    @Test
+    void test_updateCompanyInfo() {
+        final CompanyInfoResponse response = companyInfo.updateCompanyInfo(
+            domainId,
+            new UpdateCompanyInfoRequest(
+                UpdateCompanyInfoRequest.CompanyInfoData.builder()
+                    .city("New York")
+                    .zipCode("10001")
+                    .build()
+            )
+        );
+
+        assertNotNull(response);
+        assertEquals("Mailtrap", response.getData().getName());
+    }
+}

--- a/src/test/java/io/mailtrap/api/sendingdomains/SendingDomainsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingdomains/SendingDomainsImplTest.java
@@ -5,6 +5,7 @@ import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.factory.MailtrapClientFactory;
 import io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest;
 import io.mailtrap.model.request.sendingdomains.SendingDomainsSetupInstructionsRequest;
+import io.mailtrap.model.request.sendingdomains.UpdateSendingDomainRequest;
 import io.mailtrap.model.response.sendingdomains.SendingDomainsResponse;
 import io.mailtrap.testutils.BaseTest;
 import io.mailtrap.testutils.DataMock;
@@ -34,6 +35,10 @@ class SendingDomainsImplTest extends BaseTest {
             DataMock.build(
                 Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId,
                 "GET", null, "api/sending_domains/sendingDomainResponse.json"
+            ),
+            DataMock.build(
+                Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId,
+                "PATCH", "api/sending_domains/updateSendingDomainRequest.json", "api/sending_domains/sendingDomainResponse.json"
             ),
             DataMock.build(
                 Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId + "/send_setup_instructions",
@@ -82,6 +87,27 @@ class SendingDomainsImplTest extends BaseTest {
         assertEquals(6, response.getDnsRecords().size());
         assertTrue(response.isInboundEnabled());
         assertFalse(response.isInboundVerified());
+    }
+
+    @Test
+    void test_update() {
+        final SendingDomainsResponse response = domains.update(
+            accountId,
+            sendingDomainId,
+            new UpdateSendingDomainRequest(
+                UpdateSendingDomainRequest.SendingDomainData.builder()
+                    .openTrackingEnabled(true)
+                    .clickTrackingEnabled(true)
+                    .trackingOptOutEnabled(true)
+                    .autoUnsubscribeLinkEnabled(false)
+                    .inboundEnabled(false)
+                    .build()
+            )
+        );
+
+        assertNotNull(response);
+        assertEquals("test.io", response.getDomainName());
+        assertTrue(response.isTrackingOptOutEnabled());
     }
 
     @Test

--- a/src/test/resources/api/company_info/companyInfoResponse.json
+++ b/src/test/resources/api/company_info/companyInfoResponse.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "name": "Mailtrap",
+    "address": "123 Main St",
+    "city": "San Francisco",
+    "country": "US",
+    "phone": "+1-555-0100",
+    "zip_code": "94105",
+    "privacy_policy_url": "https://mailtrap.io/privacy",
+    "terms_of_service_url": "https://mailtrap.io/terms",
+    "website_url": "https://mailtrap.io",
+    "info_level": "business"
+  }
+}

--- a/src/test/resources/api/company_info/createCompanyInfoRequest.json
+++ b/src/test/resources/api/company_info/createCompanyInfoRequest.json
@@ -1,0 +1,11 @@
+{
+  "company_info": {
+    "name": "Mailtrap",
+    "address": "123 Main St",
+    "city": "San Francisco",
+    "country": "US",
+    "zip_code": "94105",
+    "website_url": "https://mailtrap.io",
+    "info_level": "business"
+  }
+}

--- a/src/test/resources/api/company_info/updateCompanyInfoRequest.json
+++ b/src/test/resources/api/company_info/updateCompanyInfoRequest.json
@@ -1,0 +1,6 @@
+{
+  "company_info": {
+    "city": "New York",
+    "zip_code": "10001"
+  }
+}

--- a/src/test/resources/api/sending_domains/sendingDomainResponse.json
+++ b/src/test/resources/api/sending_domains/sendingDomainResponse.json
@@ -56,6 +56,7 @@
   ],
   "open_tracking_enabled": true,
   "click_tracking_enabled": true,
+  "tracking_opt_out_enabled": true,
   "auto_unsubscribe_link_enabled": true,
   "custom_domain_tracking_enabled": true,
   "health_alerts_enabled": true,

--- a/src/test/resources/api/sending_domains/sendingDomainsResponse.json
+++ b/src/test/resources/api/sending_domains/sendingDomainsResponse.json
@@ -57,6 +57,7 @@
     ],
     "open_tracking_enabled": true,
     "click_tracking_enabled": true,
+    "tracking_opt_out_enabled": true,
     "auto_unsubscribe_link_enabled": true,
     "custom_domain_tracking_enabled": true,
     "health_alerts_enabled": true,

--- a/src/test/resources/api/sending_domains/updateSendingDomainRequest.json
+++ b/src/test/resources/api/sending_domains/updateSendingDomainRequest.json
@@ -1,0 +1,9 @@
+{
+  "sending_domain": {
+    "open_tracking_enabled": true,
+    "click_tracking_enabled": true,
+    "tracking_opt_out_enabled": true,
+    "auto_unsubscribe_link_enabled": false,
+    "inbound_enabled": false
+  }
+}


### PR DESCRIPTION
## Changes

Adds the sending-domain update endpoint and the nested `company_info` endpoints, which exist in the API (per `email-sending.openapi.yml`) but were missing from the SDK.

- **`SendingDomains.update`** — `PATCH` on the domain, with `UpdateSendingDomainRequest` covering `open_tracking_enabled`, `click_tracking_enabled`, `tracking_opt_out_enabled`, `auto_unsubscribe_link_enabled` and `inbound_enabled`. The inner data class uses `Boolean` with `@Builder` and `@JsonInclude(NON_NULL)`, so only the fields a caller sets are serialized and an explicit `false` survives.
- **`CompanyInfo` / `CompanyInfoImpl`** — new resource on `client.sendingApi().companyInfo()` with `getCompanyInfo` / `createCompanyInfo` / `updateCompanyInfo`. The spec path is `/api/domains/{domain_id}/company_info` and the account is resolved from the API token, so it takes no `accountId`.
- **Response shape** — the company-info methods return the `CompanyInfoResponse` envelope and callers read `.getData()`, matching `Webhooks` and the rest of this SDK rather than unwrapping in the impl.
- **DTOs** — `model/request/companyinfo/{Create,Update}CompanyInfoRequest` and `model/response/companyinfo/{CompanyInfo,CompanyInfoResponse}`.
- **`SendingDomainsResponse`** — add `tracking_opt_out_enabled`. The API returns it and `update` writes it, so callers could not read back what they had just set. Both domain fixtures were updated to include it.
- **Wiring** — adding the `companyInfo` field to `MailtrapEmailSendingApi` changes its Lombok `@RequiredArgsConstructor` signature, so `MailtrapClientFactory.createSendingApi` is updated in the same change.
- **Tests / examples** — `CompanyInfoImplTest` plus an `update` case in `SendingDomainsImplTest`, four new fixtures, a new `CompanyInfoExample`, an update block in `SendingDomainsExample`, and README entries.

`update` on the domain itself stays on the account-scoped `/api/accounts/{accountId}/sending_domains/{id}` route with the `sending_domain` wrapper, consistent with `create` / `get` / `delete` on the same resource; the API accepts both that and the spec's account-less form.