### PR TITLE
bump readme dependency version to 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ As a Maven dependency:
 <dependency>
     <groupId>io.mailtrap</groupId>
     <artifactId>mailtrap-java</artifactId>
-    <version>1.3.0</version>
+    <version>1.7.0</version>
 </dependency>
 ```
 
 As a Gradle Groovy dependency:
 
 ```groovy
-implementation 'io.mailtrap:mailtrap-java:1.3.0'
+implementation 'io.mailtrap:mailtrap-java:1.7.0'
 ```
 
 As a Gradle Kotlin DSL dependency:
 
 ```kotlin
-implementation("io.mailtrap:mailtrap-java:1.3.0")
+implementation("io.mailtrap:mailtrap-java:1.7.0")
 ```
 
 ## Usage


### PR DESCRIPTION
## Motivation

The installation snippets in the README still reference version 1.3.0, while the latest published release is 1.7.0.

## Changes

- bump the Maven and Gradle dependency snippets in the README from 1.3.0 to 1.7.0

## How to test

- [ ] README shows 1.7.0 in the Maven, Gradle Groovy, and Gradle Kotlin snippets
- [ ] adding `io.mailtrap:mailtrap-java:1.7.0` as a dependency resolves from Maven Central